### PR TITLE
Return error when path could not be resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 jmespath-fuzz.zip
 cpu.out
 go-jmespath.test
+.vscode

--- a/compliance_test.go
+++ b/compliance_test.go
@@ -93,6 +93,47 @@ func TestOrOperatorHandlesErrorPath(t *testing.T) {
 	assert.Equal(t, actual.(string), "foo")
 }
 
+func TestInvalidPathMustReturnError(t *testing.T) {
+	expression := "outer.bad"
+	givenRaw := []byte(`{
+		"outer": {
+		  "foo": "foo",
+		  "bar": "bar",
+		  "baz": "baz"
+		}
+	}`)
+
+	var given interface{}
+	var err error
+
+	err = json.Unmarshal(givenRaw, &given)
+	assert.Nil(t, err)
+
+	_, err = Search(expression, given)
+	assert.Error(t, err)
+
+	_, ok := err.(NotFoundError)
+	assert.True(t, ok)
+}
+
+func TestNullValueMustBeReturned(t *testing.T) {
+	expression := "outer.foo"
+	givenRaw := []byte(`{
+		"outer": {
+		  "foo": null
+		}
+	}`)
+
+	var given interface{}
+
+	err := json.Unmarshal(givenRaw, &given)
+	assert.Nil(t, err)
+
+	result, err := Search(expression, given)
+	assert.Nil(t, err)
+	assert.Nil(t, result)
+}
+
 func TestFilterInsideThePathHandlesErrorInPath(t *testing.T) {
 	expression := "foo[?a==`1`].b.c"
 	givenRaw := []byte(`{

--- a/functions.go
+++ b/functions.go
@@ -476,7 +476,9 @@ func jpfMap(arguments []interface{}) (interface{}, error) {
 	for _, value := range arr {
 		current, err := intr.Execute(node, value)
 		if err != nil {
-			return nil, err
+			if _, ok := err.(NotFoundError); !ok {
+				return nil, err
+			}
 		}
 		mapped = append(mapped, current)
 	}
@@ -536,7 +538,9 @@ func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 	}
 	start, err := intr.Execute(node, arr[0])
 	if err != nil {
-		return nil, err
+		if _, ok := err.(NotFoundError); !ok {
+			return nil, err
+		}
 	}
 	switch t := start.(type) {
 	case float64:
@@ -545,7 +549,9 @@ func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 		for _, item := range arr[1:] {
 			result, err := intr.Execute(node, item)
 			if err != nil {
-				return nil, err
+				if _, ok := err.(NotFoundError); !ok {
+					return nil, err
+				}
 			}
 			current, ok := result.(float64)
 			if !ok {
@@ -563,7 +569,9 @@ func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 		for _, item := range arr[1:] {
 			result, err := intr.Execute(node, item)
 			if err != nil {
-				return nil, err
+				if _, ok := err.(NotFoundError); !ok {
+					return nil, err
+				}
 			}
 			current, ok := result.(string)
 			if !ok {
@@ -632,7 +640,9 @@ func jpfMinBy(arguments []interface{}) (interface{}, error) {
 	}
 	start, err := intr.Execute(node, arr[0])
 	if err != nil {
-		return nil, err
+		if _, ok := err.(NotFoundError); !ok {
+			return nil, err
+		}
 	}
 	if t, ok := start.(float64); ok {
 		bestVal := t
@@ -640,7 +650,9 @@ func jpfMinBy(arguments []interface{}) (interface{}, error) {
 		for _, item := range arr[1:] {
 			result, err := intr.Execute(node, item)
 			if err != nil {
-				return nil, err
+				if _, ok := err.(NotFoundError); !ok {
+					return nil, err
+				}
 			}
 			current, ok := result.(float64)
 			if !ok {
@@ -658,7 +670,9 @@ func jpfMinBy(arguments []interface{}) (interface{}, error) {
 		for _, item := range arr[1:] {
 			result, err := intr.Execute(node, item)
 			if err != nil {
-				return nil, err
+				if _, ok := err.(NotFoundError); !ok {
+					return nil, err
+				}
 			}
 			current, ok := result.(string)
 			if !ok {
@@ -744,7 +758,9 @@ func jpfSortBy(arguments []interface{}) (interface{}, error) {
 	}
 	start, err := intr.Execute(node, arr[0])
 	if err != nil {
-		return nil, err
+		if _, ok := err.(NotFoundError); !ok {
+			return nil, err
+		}
 	}
 	if _, ok := start.(float64); ok {
 		sortable := &byExprFloat{intr, node, arr, false}
@@ -802,7 +818,9 @@ func jpfToString(arguments []interface{}) (interface{}, error) {
 	}
 	result, err := json.Marshal(arguments[0])
 	if err != nil {
-		return nil, err
+		if _, ok := err.(NotFoundError); !ok {
+			return nil, err
+		}
 	}
 	return string(result), nil
 }

--- a/interpreter_test.go
+++ b/interpreter_test.go
@@ -175,7 +175,7 @@ func TestCanSupportProjectionsWithStructs(t *testing.T) {
 
 func TestCanSupportSliceOfStructsWithFunctions(t *testing.T) {
 	assert := assert.New(t)
-	data := []scalars{scalars{"a1", "b1"}, scalars{"a2", "b2"}}
+	data := []scalars{{"a1", "b1"}, {"a2", "b2"}}
 	result, err := Search("length(@)", data)
 	assert.Nil(err)
 	assert.Equal(result.(float64), 2.0)


### PR DESCRIPTION
Signed-off-by: Max Goncharenko <kacejot@fex.net>

Fixes #1 

Description:
I have checked ALL possible cases of JMESPath application. That took some time, but now I'm 99% sure it will work as expected.
Expected behavior is: 

- return `null`, if we really have `null` value at some path. 
- return error, if path can't be resolved.
