### PR TITLE
Return error if subexpression is wrong

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -312,9 +312,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 	case ASTSubexpression, ASTIndexExpression:
 		left, err := intr.Execute(node.children[0], value)
 		if err != nil {
-			if _, ok := err.(NotFoundError); !ok {
-				return nil, err
-			}
+			return nil, err
 		}
 		return intr.Execute(node.children[1], left)
 	case ASTSlice:


### PR DESCRIPTION
Signed-off-by: Max Goncharenko <kacejot@fex.net>

In case, if we have `request.object.metadata2.name` (invalid key inside the sequence) we must fail.