### PR TITLE
chore: don't allow nil custom function

### DIFF
--- a/api.go
+++ b/api.go
@@ -48,6 +48,6 @@ func Search(expression string, data interface{}) (interface{}, error) {
 	return intr.Execute(ast, data)
 }
 
-func (jp *JMESPath) Register(f *FunctionEntry) {
-	jp.intr.fCall.functionTable[f.Name] = *f
+func (jp *JMESPath) Register(f FunctionEntry) {
+	jp.intr.fCall.functionTable[f.Name] = f
 }

--- a/api_test.go
+++ b/api_test.go
@@ -49,17 +49,16 @@ func TestCustomFunction(t *testing.T) {
 	data := make(map[string]interface{})
 	data["foo"] = "BAR"
 	precompiled, err := Compile("to_lower(foo)")
-	precompiled.Register(&FunctionEntry{
+	precompiled.Register(FunctionEntry{
 		Name: "to_lower",
 		Arguments: []ArgSpec{
 			{Types: []JpType{JpString}},
 		},
-		Handler: func (arguments []interface{}) (interface{}, error) {
+		Handler: func(arguments []interface{}) (interface{}, error) {
 			s := arguments[0].(string)
 			return strings.ToLower(s), nil
 		},
 	})
-
 	assert.Nil(err)
 	result, err := precompiled.Search(data)
 	assert.Nil(err)


### PR DESCRIPTION
This PR prevents registering custom functions with `nil`.