### PR TITLE
fix type confusion

### DIFF
--- a/interpreter.go
+++ b/interpreter.go
@@ -80,6 +80,9 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 	case ASTExpRef:
 		return expRef{ref: node.Children[0]}, nil
 	case ASTFunctionExpression:
+		if _, ok := node.Value.(string); !ok {
+			return nil, errors.New("invalid node value type")
+		}
 		resolvedArgs := []interface{}{}
 		for _, arg := range node.Children {
 			current, err := intr.Execute(arg, value)


### PR DESCRIPTION
Fixes a type confusion found by OSS-Fuzz: https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=62568

`node.Value` can be `nil` which throws a panic.