### PR TITLE
refactor(api): expose FunctionCaller

### DIFF
--- a/api_test.go
+++ b/api_test.go
@@ -48,8 +48,10 @@ func TestCustomFunction(t *testing.T) {
 	assert := assert.New(t)
 	data := make(map[string]interface{})
 	data["foo"] = "BAR"
+
 	precompiled, err := Compile("to_lower(foo)")
-	precompiled.Register(FunctionEntry{
+	fCall := NewFunctionCaller()
+	fCall.Register(FunctionEntry{
 		Name: "to_lower",
 		Arguments: []ArgSpec{
 			{Types: []JpType{JpString}},
@@ -60,7 +62,7 @@ func TestCustomFunction(t *testing.T) {
 		},
 	})
 	assert.Nil(err)
-	result, err := precompiled.Search(data)
+	result, err := precompiled.Search(data, WithFunctionCaller(fCall))
 	assert.Nil(err)
 	assert.Equal("bar", result)
 }

--- a/functions.go
+++ b/functions.go
@@ -42,6 +42,7 @@ type ArgSpec struct {
 
 type byExprString struct {
 	intr     *treeInterpreter
+	fCall    *FunctionCaller
 	node     ASTNode
 	items    []interface{}
 	hasError bool
@@ -54,7 +55,7 @@ func (a *byExprString) Swap(i, j int) {
 	a.items[i], a.items[j] = a.items[j], a.items[i]
 }
 func (a *byExprString) Less(i, j int) bool {
-	first, err := a.intr.Execute(a.node, a.items[i])
+	first, err := a.intr.execute(a.node, a.items[i], a.fCall)
 	if err != nil {
 		a.hasError = true
 		// Return a dummy value.
@@ -65,7 +66,7 @@ func (a *byExprString) Less(i, j int) bool {
 		a.hasError = true
 		return true
 	}
-	second, err := a.intr.Execute(a.node, a.items[j])
+	second, err := a.intr.execute(a.node, a.items[j], a.fCall)
 	if err != nil {
 		a.hasError = true
 		// Return a dummy value.
@@ -81,6 +82,7 @@ func (a *byExprString) Less(i, j int) bool {
 
 type byExprFloat struct {
 	intr     *treeInterpreter
+	fCall    *FunctionCaller
 	node     ASTNode
 	items    []interface{}
 	hasError bool
@@ -93,7 +95,7 @@ func (a *byExprFloat) Swap(i, j int) {
 	a.items[i], a.items[j] = a.items[j], a.items[i]
 }
 func (a *byExprFloat) Less(i, j int) bool {
-	first, err := a.intr.Execute(a.node, a.items[i])
+	first, err := a.intr.execute(a.node, a.items[i], a.fCall)
 	if err != nil {
 		a.hasError = true
 		// Return a dummy value.
@@ -104,7 +106,7 @@ func (a *byExprFloat) Less(i, j int) bool {
 		a.hasError = true
 		return true
 	}
-	second, err := a.intr.Execute(a.node, a.items[j])
+	second, err := a.intr.execute(a.node, a.items[j], a.fCall)
 	if err != nil {
 		a.hasError = true
 		// Return a dummy value.
@@ -400,6 +402,7 @@ func (f *FunctionCaller) CallFunction(name string, arguments []interface{}, intr
 	if entry.HasExpRef {
 		var extra []interface{}
 		extra = append(extra, intr)
+		extra = append(extra, f)
 		resolvedArgs = append(extra, resolvedArgs...)
 	}
 	return entry.Handler(resolvedArgs)
@@ -473,12 +476,13 @@ func jpfFloor(arguments []interface{}) (interface{}, error) {
 }
 func jpfMap(arguments []interface{}) (interface{}, error) {
 	intr := arguments[0].(*treeInterpreter)
-	exp := arguments[1].(expRef)
+	fCall := arguments[1].(*FunctionCaller)
+	exp := arguments[2].(expRef)
 	node := exp.ref
-	arr := arguments[2].([]interface{})
+	arr := arguments[3].([]interface{})
 	mapped := make([]interface{}, 0, len(arr))
 	for _, value := range arr {
-		current, err := intr.Execute(node, value)
+		current, err := intr.execute(node, value, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
@@ -532,15 +536,16 @@ func jpfMerge(arguments []interface{}) (interface{}, error) {
 }
 func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 	intr := arguments[0].(*treeInterpreter)
-	arr := arguments[1].([]interface{})
-	exp := arguments[2].(expRef)
+	fCall := arguments[1].(*FunctionCaller)
+	arr := arguments[2].([]interface{})
+	exp := arguments[3].(expRef)
 	node := exp.ref
 	if len(arr) == 0 {
 		return nil, nil
 	} else if len(arr) == 1 {
 		return arr[0], nil
 	}
-	start, err := intr.Execute(node, arr[0])
+	start, err := intr.execute(node, arr[0], fCall)
 	if err != nil {
 		if _, ok := err.(NotFoundError); !ok {
 			return nil, err
@@ -551,7 +556,7 @@ func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := intr.Execute(node, item)
+			result, err := intr.execute(node, item, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -571,7 +576,7 @@ func jpfMaxBy(arguments []interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := intr.Execute(node, item)
+			result, err := intr.execute(node, item, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -634,15 +639,16 @@ func jpfMin(arguments []interface{}) (interface{}, error) {
 
 func jpfMinBy(arguments []interface{}) (interface{}, error) {
 	intr := arguments[0].(*treeInterpreter)
-	arr := arguments[1].([]interface{})
-	exp := arguments[2].(expRef)
+	fCall := arguments[1].(*FunctionCaller)
+	arr := arguments[2].([]interface{})
+	exp := arguments[3].(expRef)
 	node := exp.ref
 	if len(arr) == 0 {
 		return nil, nil
 	} else if len(arr) == 1 {
 		return arr[0], nil
 	}
-	start, err := intr.Execute(node, arr[0])
+	start, err := intr.execute(node, arr[0], fCall)
 	if err != nil {
 		if _, ok := err.(NotFoundError); !ok {
 			return nil, err
@@ -652,7 +658,7 @@ func jpfMinBy(arguments []interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := intr.Execute(node, item)
+			result, err := intr.execute(node, item, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -672,7 +678,7 @@ func jpfMinBy(arguments []interface{}) (interface{}, error) {
 		bestVal := t
 		bestItem := arr[0]
 		for _, item := range arr[1:] {
-			result, err := intr.Execute(node, item)
+			result, err := intr.execute(node, item, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -752,29 +758,30 @@ func jpfSort(arguments []interface{}) (interface{}, error) {
 }
 func jpfSortBy(arguments []interface{}) (interface{}, error) {
 	intr := arguments[0].(*treeInterpreter)
-	arr := arguments[1].([]interface{})
-	exp := arguments[2].(expRef)
+	fCall := arguments[1].(*FunctionCaller)
+	arr := arguments[2].([]interface{})
+	exp := arguments[3].(expRef)
 	node := exp.ref
 	if len(arr) == 0 {
 		return arr, nil
 	} else if len(arr) == 1 {
 		return arr, nil
 	}
-	start, err := intr.Execute(node, arr[0])
+	start, err := intr.execute(node, arr[0], fCall)
 	if err != nil {
 		if _, ok := err.(NotFoundError); !ok {
 			return nil, err
 		}
 	}
 	if _, ok := start.(float64); ok {
-		sortable := &byExprFloat{intr, node, arr, false}
+		sortable := &byExprFloat{intr, fCall, node, arr, false}
 		sort.Stable(sortable)
 		if sortable.hasError {
 			return nil, errors.New("error in sort_by comparison")
 		}
 		return arr, nil
 	} else if _, ok := start.(string); ok {
-		sortable := &byExprString{intr, node, arr, false}
+		sortable := &byExprString{intr, fCall, node, arr, false}
 		sort.Stable(sortable)
 		if sortable.hasError {
 			return nil, errors.New("error in sort_by comparison")

--- a/functions.go
+++ b/functions.go
@@ -118,12 +118,12 @@ func (a *byExprFloat) Less(i, j int) bool {
 	return ith < jth
 }
 
-type functionCaller struct {
+type FunctionCaller struct {
 	functionTable map[string]FunctionEntry
 }
 
-func newFunctionCaller() *functionCaller {
-	caller := &functionCaller{}
+func NewFunctionCaller() *FunctionCaller {
+	caller := &FunctionCaller{}
 	caller.functionTable = map[string]FunctionEntry{
 		"length": {
 			Name: "length",
@@ -323,6 +323,10 @@ func newFunctionCaller() *functionCaller {
 	return caller
 }
 
+func (f *FunctionCaller) Register(e FunctionEntry) {
+	f.functionTable[e.Name] = e
+}
+
 func (e *FunctionEntry) resolveArgs(arguments []interface{}) ([]interface{}, error) {
 	if len(e.Arguments) == 0 {
 		return arguments, nil
@@ -384,7 +388,7 @@ func (a *ArgSpec) typeCheck(arg interface{}) error {
 	return fmt.Errorf("Invalid type for: %v, expected: %#v", arg, a.Types)
 }
 
-func (f *functionCaller) CallFunction(name string, arguments []interface{}, intr *treeInterpreter) (interface{}, error) {
+func (f *FunctionCaller) CallFunction(name string, arguments []interface{}, intr *treeInterpreter) (interface{}, error) {
 	entry, ok := f.functionTable[name]
 	if !ok {
 		return nil, errors.New("unknown function: " + name)

--- a/interpreter.go
+++ b/interpreter.go
@@ -22,12 +22,19 @@ func (n NotFoundError) Error() string {
  * interprets the AST to search through a JSON document.
  */
 type treeInterpreter struct {
-	fCall *functionCaller
+	fCall *FunctionCaller
 }
 
 func NewInterpreter() *treeInterpreter {
 	interpreter := treeInterpreter{}
-	interpreter.fCall = newFunctionCaller()
+	interpreter.fCall = NewFunctionCaller()
+	return &interpreter
+}
+
+func NewInterpreterFromFunctionCaller(caller *FunctionCaller) *treeInterpreter {
+	interpreter := treeInterpreter{
+		fCall: caller,
+	}
 	return &interpreter
 }
 

--- a/interpreter.go
+++ b/interpreter.go
@@ -39,7 +39,7 @@ type expRef struct {
 	ref ASTNode
 }
 
-// execute takes an ASTNode and input data and interprets the AST directly.
+// Execute takes an ASTNode and input data and interprets the AST directly.
 // It will produce the result of applying the JMESPath expression associated
 // with the ASTNode to the input data "value".
 func (intr *treeInterpreter) Execute(node ASTNode, value interface{}, opts ...InterpreterOption) (interface{}, error) {

--- a/interpreter.go
+++ b/interpreter.go
@@ -17,24 +17,21 @@ func (n NotFoundError) Error() string {
 	return fmt.Sprintf("Unknown key \"%s\" in path", n.key)
 }
 
+var DefaultFunctionCaller *FunctionCaller = NewFunctionCaller()
+
+type Interpreter interface {
+	// Interpret the node and return results
+	Execute(node ASTNode, value interface{}, opts ...InterpreterOption) (interface{}, error)
+}
+
 /*
  * This is a tree based interpreter.  It walks the AST and directly
  * interprets the AST to search through a JSON document.
  */
-type treeInterpreter struct {
-	fCall *FunctionCaller
-}
+type treeInterpreter struct{}
 
 func NewInterpreter() *treeInterpreter {
 	interpreter := treeInterpreter{}
-	interpreter.fCall = NewFunctionCaller()
-	return &interpreter
-}
-
-func NewInterpreterFromFunctionCaller(caller *FunctionCaller) *treeInterpreter {
-	interpreter := treeInterpreter{
-		fCall: caller,
-	}
 	return &interpreter
 }
 
@@ -42,19 +39,33 @@ type expRef struct {
 	ref ASTNode
 }
 
-// Execute takes an ASTNode and input data and interprets the AST directly.
+// execute takes an ASTNode and input data and interprets the AST directly.
 // It will produce the result of applying the JMESPath expression associated
 // with the ASTNode to the input data "value".
-func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface{}, error) {
+func (intr *treeInterpreter) Execute(node ASTNode, value interface{}, opts ...InterpreterOption) (interface{}, error) {
+	var o interpreterOptions
+	for _, opt := range opts {
+		if opt != nil {
+			o = opt(o)
+		}
+	}
+	functionCaller := o.functionCaller
+	if functionCaller == nil {
+		functionCaller = DefaultFunctionCaller
+	}
+	return intr.execute(node, value, functionCaller)
+}
+
+func (intr *treeInterpreter) execute(node ASTNode, value interface{}, fCall *FunctionCaller) (interface{}, error) {
 	switch node.NodeType {
 	case ASTComparator:
-		left, err := intr.Execute(node.Children[0], value)
+		left, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
 			}
 		}
-		right, err := intr.Execute(node.Children[1], value)
+		right, err := intr.execute(node.Children[1], value, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
@@ -92,7 +103,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		resolvedArgs := []interface{}{}
 		for _, arg := range node.Children {
-			current, err := intr.Execute(arg, value)
+			current, err := intr.execute(arg, value, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -100,7 +111,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 			}
 			resolvedArgs = append(resolvedArgs, current)
 		}
-		return intr.fCall.CallFunction(node.Value.(string), resolvedArgs, intr)
+		return fCall.CallFunction(node.Value.(string), resolvedArgs, intr)
 	case ASTField:
 		if m, ok := value.(map[string]interface{}); ok {
 			key := node.Value.(string)
@@ -112,28 +123,28 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return intr.fieldFromStruct(node.Value.(string), value)
 	case ASTFilterProjection:
-		left, err := intr.Execute(node.Children[0], value)
+		left, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			return nil, nil
 		}
 		sliceType, ok := left.([]interface{})
 		if !ok {
 			if isSliceType(left) {
-				return intr.filterProjectionWithReflection(node, left)
+				return intr.filterProjectionWithReflection(node, left, fCall)
 			}
 			return nil, nil
 		}
 		compareNode := node.Children[2]
 		collected := []interface{}{}
 		for _, element := range sliceType {
-			result, err := intr.Execute(compareNode, element)
+			result, err := intr.execute(compareNode, element, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
 				}
 			}
 			if !isFalse(result) {
-				current, err := intr.Execute(node.Children[1], element)
+				current, err := intr.execute(node.Children[1], element, fCall)
 				if err != nil {
 					if _, ok := err.(NotFoundError); !ok {
 						return nil, err
@@ -146,7 +157,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return collected, nil
 	case ASTFlatten:
-		left, err := intr.Execute(node.Children[0], value)
+		left, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			return nil, nil
 		}
@@ -203,7 +214,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return nil, nil
 	case ASTKeyValPair:
-		return intr.Execute(node.Children[0], value)
+		return intr.execute(node.Children[0], value, fCall)
 	case ASTLiteral:
 		return node.Value, nil
 	case ASTMultiSelectHash:
@@ -212,7 +223,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		collected := make(map[string]interface{})
 		for _, child := range node.Children {
-			current, err := intr.Execute(child, value)
+			current, err := intr.execute(child, value, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -228,7 +239,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		collected := []interface{}{}
 		for _, child := range node.Children {
-			current, err := intr.Execute(child, value)
+			current, err := intr.execute(child, value, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -238,7 +249,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return collected, nil
 	case ASTOrExpression:
-		matched, err := intr.Execute(node.Children[0], value)
+		matched, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); ok {
 				matched = nil
@@ -249,7 +260,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 			}
 		}
 		if isFalse(matched) {
-			matched, err = intr.Execute(node.Children[1], value)
+			matched, err = intr.execute(node.Children[1], value, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -258,7 +269,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return matched, nil
 	case ASTAndExpression:
-		matched, err := intr.Execute(node.Children[0], value)
+		matched, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
@@ -267,9 +278,9 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		if isFalse(matched) {
 			return matched, nil
 		}
-		return intr.Execute(node.Children[1], value)
+		return intr.execute(node.Children[1], value, fCall)
 	case ASTNotExpression:
-		matched, err := intr.Execute(node.Children[0], value)
+		matched, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
@@ -283,7 +294,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		result := value
 		var err error
 		for _, child := range node.Children {
-			result, err = intr.Execute(child, result)
+			result, err = intr.execute(child, result, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -292,7 +303,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return result, nil
 	case ASTProjection:
-		left, err := intr.Execute(node.Children[0], value)
+		left, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
@@ -301,14 +312,14 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		sliceType, ok := left.([]interface{})
 		if !ok {
 			if isSliceType(left) {
-				return intr.projectWithReflection(node, left)
+				return intr.projectWithReflection(node, left, fCall)
 			}
 			return nil, nil
 		}
 		collected := []interface{}{}
 		var current interface{}
 		for _, element := range sliceType {
-			current, err = intr.Execute(node.Children[1], element)
+			current, err = intr.execute(node.Children[1], element, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -320,11 +331,11 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return collected, nil
 	case ASTSubexpression, ASTIndexExpression:
-		left, err := intr.Execute(node.Children[0], value)
+		left, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			return nil, err
 		}
-		return intr.Execute(node.Children[1], left)
+		return intr.execute(node.Children[1], left, fCall)
 	case ASTSlice:
 		sliceType, ok := value.([]interface{})
 		if !ok {
@@ -343,7 +354,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		return slice(sliceType, sliceParams)
 	case ASTValueProjection:
-		left, err := intr.Execute(node.Children[0], value)
+		left, err := intr.execute(node.Children[0], value, fCall)
 		if err != nil {
 			return nil, nil
 		}
@@ -357,7 +368,7 @@ func (intr *treeInterpreter) Execute(node ASTNode, value interface{}) (interface
 		}
 		collected := []interface{}{}
 		for _, element := range values {
-			current, err := intr.Execute(node.Children[1], element)
+			current, err := intr.execute(node.Children[1], element, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -436,20 +447,20 @@ func (intr *treeInterpreter) sliceWithReflection(node ASTNode, value interface{}
 	return slice(final, sliceParams)
 }
 
-func (intr *treeInterpreter) filterProjectionWithReflection(node ASTNode, value interface{}) (interface{}, error) {
+func (intr *treeInterpreter) filterProjectionWithReflection(node ASTNode, value interface{}, fCall *FunctionCaller) (interface{}, error) {
 	compareNode := node.Children[2]
 	collected := []interface{}{}
 	v := reflect.ValueOf(value)
 	for i := 0; i < v.Len(); i++ {
 		element := v.Index(i).Interface()
-		result, err := intr.Execute(compareNode, element)
+		result, err := intr.execute(compareNode, element, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
 			}
 		}
 		if !isFalse(result) {
-			current, err := intr.Execute(node.Children[1], element)
+			current, err := intr.execute(node.Children[1], element, fCall)
 			if err != nil {
 				if _, ok := err.(NotFoundError); !ok {
 					return nil, err
@@ -463,12 +474,12 @@ func (intr *treeInterpreter) filterProjectionWithReflection(node ASTNode, value 
 	return collected, nil
 }
 
-func (intr *treeInterpreter) projectWithReflection(node ASTNode, value interface{}) (interface{}, error) {
+func (intr *treeInterpreter) projectWithReflection(node ASTNode, value interface{}, fCall *FunctionCaller) (interface{}, error) {
 	collected := []interface{}{}
 	v := reflect.ValueOf(value)
 	for i := 0; i < v.Len(); i++ {
 		element := v.Index(i).Interface()
-		result, err := intr.Execute(node.Children[1], element)
+		result, err := intr.execute(node.Children[1], element, fCall)
 		if err != nil {
 			if _, ok := err.(NotFoundError); !ok {
 				return nil, err
@@ -479,8 +490,4 @@ func (intr *treeInterpreter) projectWithReflection(node ASTNode, value interface
 		}
 	}
 	return collected, nil
-}
-
-func (intr *treeInterpreter) Register(f FunctionEntry) {
-	intr.fCall.functionTable[f.Name] = f
 }

--- a/interpreter_option.go
+++ b/interpreter_option.go
@@ -1,0 +1,14 @@
+package jmespath
+
+type InterpreterOption func(interpreterOptions) interpreterOptions
+
+type interpreterOptions struct {
+	functionCaller *FunctionCaller
+}
+
+func WithFunctionCaller(functionCaller *FunctionCaller) InterpreterOption {
+	return func(o interpreterOptions) interpreterOptions {
+		o.functionCaller = functionCaller
+		return o
+	}
+}


### PR DESCRIPTION
* Make FunctionCaller public
* Move `Register()` method to FunctionCaller
* Add Function to create Interpreter from FunctionCaller

Doesn't break backward compatability